### PR TITLE
Add optional cross-validation to transfer experiments

### DIFF
--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -131,3 +131,26 @@ def test_transfer_experiment_mlp(monkeypatch):
     assert "auc" in results
     # Should include sex-specific accuracy metrics
     assert any(k.startswith("accuracy_") for k in results)
+
+
+def test_transfer_experiment_cv():
+    """Ensure cross-validation path executes for classical models."""
+    source = pd.DataFrame(
+        {
+            "feat": [0, 1, 0, 1, 0, 1, 0, 1],
+            "sex": [0, 1, 0, 1, 0, 1, 0, 1],
+            "label": [0, 1, 0, 1, 0, 1, 0, 1],
+        }
+    )
+    target = pd.DataFrame(
+        {
+            "feat": [0, 1],
+            "sex": [0, 1],
+            "label": [0, 1],
+        }
+    )
+
+    results = uci_transfer.transfer_experiment(
+        source, target, model_type="logistic", use_cv=True
+    )
+    assert "accuracy" in results


### PR DESCRIPTION
## Summary
- Allow `transfer_experiment` to optionally perform cross-validation hyperparameter search
- Propagate a new `--cv` flag through CLI and `run_bidirectional_transfer`
- Test cross-validation path for classical models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1b96cdcc8322925cdcf1146a86e0